### PR TITLE
Update library versions in .cabal file for GHC 7.6

### DIFF
--- a/pointfree.cabal
+++ b/pointfree.cabal
@@ -29,9 +29,9 @@ Executable pointfree
                  ImplicitParams,
                  PatternGuards,
                  ScopedTypeVariables
-  Build-depends: base >= 3 && < 4.6,
+  Build-depends: base >= 3 && < 4.7,
                  array >= 0.3 && < 0.5,
-                 containers >= 0.3 && < 0.5,
+                 containers >= 0.3 && < 0.6,
                  parsec >= 2 && < 3.2,
                  mtl >= 2 && < 2.2
   Other-modules: Plugin.Pl.Common


### PR DESCRIPTION
Incremented the upper bounds for base and containers versions.
