### PR TITLE
Allow building with GHC 7.10

### DIFF
--- a/pointfree.cabal
+++ b/pointfree.cabal
@@ -31,7 +31,7 @@ Executable pointfree
                  ImplicitParams,
                  PatternGuards,
                  ScopedTypeVariables
-  Build-depends: base >= 4.3 && < 4.8,
+  Build-depends: base >= 4.3 && < 4.9,
                  array >= 0.3 && < 0.6,
                  containers >= 0.4 && < 0.6,
                  haskell-src-exts == 1.16.*,


### PR DESCRIPTION
`pointfree` builds fine with `base-4.8.0.0`, so bump its upper version bound to allow it to build with GHC 7.10.