### PR TITLE
Create a library

### DIFF
--- a/Pointfree.hs
+++ b/Pointfree.hs
@@ -1,0 +1,31 @@
+module Pointfree where
+
+import Plugin.Pl.Common (mapTopLevel, mapTopLevel')
+import Plugin.Pl.Optimize (optimize)
+import Plugin.Pl.Parser (parsePF)
+import Plugin.Pl.PrettyPrinter (prettyTopLevel)
+import Plugin.Pl.Transform (transform)
+
+import Data.Maybe (listToMaybe)
+
+{- |
+  >>> pointfree "I'm not a valid Haskell expression!"
+  []
+  >>> pointfree "sum xs = foldr (+) 0 xs"
+  ["sum = id (fix (const (foldr (+) 0)))","sum = fix (const (foldr (+) 0))","sum = foldr (+) 0"]
+-}
+pointfree :: String -> [String]
+pointfree
+  = either
+    (const [])
+    (map prettyTopLevel . mapTopLevel' optimize . mapTopLevel transform)
+  . parsePF
+
+{- |
+  >>> pointfree' "I'm not a valid Haskell expression!"
+  Nothing
+  >>> pointfree' "sum xs = foldr (+) 0 xs"
+  Just "sum = foldr (+) 0"
+-}
+pointfree' :: String -> Maybe String
+pointfree' = listToMaybe . reverse . pointfree

--- a/pointfree.cabal
+++ b/pointfree.cabal
@@ -23,6 +23,21 @@ Source-repository head
   type:     git
   location: git://github.com/benmachine/pointfree.git
 
+library
+    Exposed-modules: Pointfree
+    Build-depends: base >= 4.3 && < 4.9,
+                   array >= 0.3 && < 0.6,
+                   containers >= 0.4 && < 0.6,
+                   haskell-src-exts == 1.16.*,
+                   transformers < 0.5
+    Other-modules: Plugin.Pl.Common
+                   Plugin.Pl.Parser
+                   Plugin.Pl.PrettyPrinter
+                   Plugin.Pl.Optimize
+                   Plugin.Pl.Rules
+                   Plugin.Pl.Transform
+    GHC-options: -Wall
+
 Executable pointfree
   Main-is:       Main.hs
   GHC-options:   -Wall


### PR DESCRIPTION
The readme says:

> It would be nice to make pointfree a library that operated on ASTs, or at the very least on strings.

This pull request adds a library that operates on strings. It adds one module, `Pointfree`, and two functions in that module, `pointfree` and `pointfree'`. The former behaves like the verbose mode by returning a list; the latter simply returns a maybe. 

``` hs
pointfree "I'm not a valid Haskell expression!"
-- []
pointfree "sum xs = foldr (+) 0 xs"
-- ["sum = id (fix (const (foldr (+) 0)))","sum = fix (const (foldr (+) 0))","sum = foldr (+) 0"]

pointfree' "I'm not a valid Haskell expression!"
-- Nothing
pointfree' "sum xs = foldr (+) 0 xs"
-- Just "sum = foldr (+) 0"
```