### PR TITLE
Stop hard-coded variable names interfering with names from input

### DIFF
--- a/Plugin/Pl/Transform.hs
+++ b/Plugin/Pl/Transform.hs
@@ -100,14 +100,14 @@ fresh :: [String] -> String
 fresh variables = head . filter (not . flip elem variables) $ varNames
 
 names :: Expr -> [String]
-names (Var _ str)      = [str]
+names (Var _ str)     = [str]
 -- Lambda pattern names are rewritten to be meaningless/unwritable, so we don't
--- need to include them here. Variables from lambdas used in patterns are also
--- rewritten, but there's no reason to special-case it unless it's provably
--- poor-performing
-names (Lambda _ exp) = names exp
-names (App exp1 exp2)  = names exp1 ++ names exp2
-names (Let dlcs exp)   = concatMap dnames dlcs ++ names exp
+-- need to include them here. Variables from lambdas used in expressions are
+-- also rewritten, but there's no reason to special-case it unless it's provably
+-- poor-performing to scan over the result in `fresh`, which I doubt it is.
+names (Lambda _ exp)  = names exp
+names (App exp1 exp2) = names exp1 ++ names exp2
+names (Let dlcs exp)  = concatMap dnames dlcs ++ names exp
   where
     dnames (Define nm exp) = nm : names exp
 

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -187,7 +187,8 @@ unitTests = TestList [
   unitTest "(\\n -> (return 0) ± (return $ sqrt n))" ["(return 0 ±) . return . sqrt"],
   unitTest "\\b -> (\\c -> ((Control.Monad.>>=) c) (\\g -> Control.Applicative.pure (b g)))"
     ["flip (Control.Monad.>>=) . (Control.Applicative.pure .)"],
-  unitTest "\\(x, y) -> z" ["const z"]
+  unitTest "\\(x, y) -> z" ["const z"],
+  unitTest "\\(x, y) -> a" ["const a"]
   ]
 
 main :: IO ()

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -186,7 +186,8 @@ unitTests = TestList [
   unitTest "let x = const 3 y; y = const 4 x in x + y" ["7"], -- yay!
   unitTest "(\\n -> (return 0) ± (return $ sqrt n))" ["(return 0 ±) . return . sqrt"],
   unitTest "\\b -> (\\c -> ((Control.Monad.>>=) c) (\\g -> Control.Applicative.pure (b g)))"
-    ["flip (Control.Monad.>>=) . (Control.Applicative.pure .)"]
+    ["flip (Control.Monad.>>=) . (Control.Applicative.pure .)"],
+  unitTest "\\(x, y) -> z" ["const z"]
   ]
 
 main :: IO ()


### PR DESCRIPTION
Fixes https://github.com/bmillwood/pointfree/issues/12. I just solved this in the most immediately apparent way to me, if I'm missing something then please point it out.