### PR TITLE
Simple version bumps

### DIFF
--- a/pointfree.cabal
+++ b/pointfree.cabal
@@ -29,7 +29,7 @@ Library
   Build-depends: base >= 4.5 && < 4.13,
                  array >= 0.3 && < 0.6,
                  containers >= 0.4 && < 0.7,
-                 haskell-src-exts >= 1.20 && < 1.21,
+                 haskell-src-exts >= 1.20 && < 1.24,
                  transformers < 0.6
   Other-modules: Plugin.Pl.Common
                  Plugin.Pl.Parser
@@ -45,7 +45,7 @@ Executable pointfree
   Build-depends: base >= 4.5 && < 4.13,
                  array >= 0.3 && < 0.6,
                  containers >= 0.4 && < 0.7,
-                 haskell-src-exts >= 1.20 && < 1.21,
+                 haskell-src-exts >= 1.20 && < 1.24,
                  transformers < 0.6
   Other-modules: Plugin.Pl.Common
                  Plugin.Pl.Parser
@@ -69,9 +69,9 @@ Test-suite tests
     base >= 4.5 && < 4.13,
     array >= 0.3 && < 0.6,
     containers >= 0.4 && < 0.7,
-    haskell-src-exts >= 1.20 && < 1.21,
+    haskell-src-exts >= 1.20 && < 1.24,
     HUnit >= 1.6 && < 1.7,
-    QuickCheck >= 2.11 && < 2.13,
+    QuickCheck >= 2.11 && < 2.14,
     transformers < 0.6
 
   GHC-Options:    -W


### PR DESCRIPTION
I'm working to update `haskell-src-exts` in the Gentoo Haskell packages, and this is one of the packages pinning it to a lower version.  I've tested on my system, and the upper bound there seems to be safe to bump to `< 1.24`; everything up to 1.23 builds with successful tests.  At the same time, `QuickCheck < 2.14` also seems safe.  ~I'll create an issue for `base` since there's a bit of fixing for that one that's not quite compatible.~

EDIT: I thought I had already checked the PRs; #32 already covers `base`.