### PR TITLE
Added MonadFail constraint to Plugin.Pl.Common, bumped version numbers.

### DIFF
--- a/Plugin/Pl/Common.hs
+++ b/Plugin/Pl/Common.hs
@@ -17,6 +17,7 @@ import Data.List (intersperse, minimumBy)
 import qualified Data.Map as M
 
 import Control.Monad
+
 import Control.Arrow (first, second, (***), (&&&), (|||), (+++))
 
 import Language.Haskell.Exts (Assoc(..))
@@ -136,7 +137,7 @@ lookupFix str = case lookupOp $ str of
   Nothing -> ((AssocLeft ()), 9 + shift)
   Just x  -> x
 
-readM :: (Monad m, Read a) => String -> m a
+readM :: (Monad m, MonadFail m, Read a) => String -> m a
 readM s = case [x | (x,t) <- reads s, ("","")  <- lex t] of
             [x] -> return x
             []  -> fail "readM: No parse."

--- a/pointfree.cabal
+++ b/pointfree.cabal
@@ -1,7 +1,7 @@
 Cabal-Version: >= 1.8
 
 Name:     pointfree
-Version:  1.1.1.6
+Version:  1.1.1.5
 Category: Tool
 Synopsis: Tool for refactoring expressions into pointfree form
 
@@ -17,7 +17,7 @@ License-file: LICENSE
 Extra-source-files: ChangeLog README test/Test.hs
 
 Build-type:  Simple
-Tested-with: GHC == 8.6.4
+Tested-with: GHC == 8.10.1
 
 Source-repository head
   type:     git

--- a/pointfree.cabal
+++ b/pointfree.cabal
@@ -71,7 +71,7 @@ Test-suite tests
     containers >= 0.4 && < 0.7,
     haskell-src-exts >= 1.20 && < 1.23.1,
     HUnit >= 1.6 && < 1.7,
-    QuickCheck >= 2.11 && < 2.13,
+    QuickCheck >= 2.11 && < 2.15,
     transformers < 0.6
 
   GHC-Options:    -W

--- a/pointfree.cabal
+++ b/pointfree.cabal
@@ -1,7 +1,7 @@
 Cabal-Version: >= 1.8
 
 Name:     pointfree
-Version:  1.1.1.5
+Version:  1.1.1.6
 Category: Tool
 Synopsis: Tool for refactoring expressions into pointfree form
 
@@ -26,10 +26,10 @@ Source-repository head
 Library
   Exposed-modules: Pointfree
 
-  Build-depends: base >= 4.5 && < 4.13,
+  Build-depends: base >= 4.5 && <= 4.15,
                  array >= 0.3 && < 0.6,
                  containers >= 0.4 && < 0.7,
-                 haskell-src-exts >= 1.20 && < 1.21,
+                 haskell-src-exts >= 1.20 && <= 1.23.1,
                  transformers < 0.6
   Other-modules: Plugin.Pl.Common
                  Plugin.Pl.Parser
@@ -42,10 +42,10 @@ Library
 Executable pointfree
   Main-is:       Main.hs
   GHC-options:   -W
-  Build-depends: base >= 4.5 && < 4.13,
+  Build-depends: base >= 4.5 && <= 4.15,
                  array >= 0.3 && < 0.6,
                  containers >= 0.4 && < 0.7,
-                 haskell-src-exts >= 1.20 && < 1.21,
+                 haskell-src-exts >= 1.20 && < 1.23.1,
                  transformers < 0.6
   Other-modules: Plugin.Pl.Common
                  Plugin.Pl.Parser
@@ -66,10 +66,10 @@ Test-suite tests
                  Plugin.Pl.Transform
 
   Build-depends:
-    base >= 4.5 && < 4.13,
+    base >= 4.5 && <= 4.15,
     array >= 0.3 && < 0.6,
     containers >= 0.4 && < 0.7,
-    haskell-src-exts >= 1.20 && < 1.21,
+    haskell-src-exts >= 1.20 && < 1.23.1,
     HUnit >= 1.6 && < 1.7,
     QuickCheck >= 2.11 && < 2.13,
     transformers < 0.6


### PR DESCRIPTION
GHC 8.8 removed `fail` from the Monad class in favour of adding `MonadFail`. Fixed the class constraint in `readM` to reflect these changes, and updated dependency versions in `pointfree.cabal`.

Test suite passed, I didn't bump the version number of the package itself in `pointfree.cabal`.

Solves #34 