### PR TITLE
Propogate both error messages when both parses fail 

### DIFF
--- a/Plugin/Pl/Parser.hs
+++ b/Plugin/Pl/Parser.hs
@@ -2,7 +2,6 @@ module Plugin.Pl.Parser (parsePF) where
 
 import Plugin.Pl.Common
 
-import Data.List (intercalate)
 import qualified Language.Haskell.Exts as HSE
 
 todo :: (Functor e, Show (e ())) => e a -> r
@@ -96,10 +95,10 @@ parsePF inp = case HSE.parseExpWithMode parseMode inp of
   HSE.ParseOk e -> Right (TLE (hseToExpr e))
   HSE.ParseFailed _ expParseErr -> case HSE.parseDeclWithMode parseMode inp of
     HSE.ParseOk d -> Right (TLD True (hseToDecl d))
-    HSE.ParseFailed _ declParseErr -> Left (joinErrorMessages expParseErr declParseErr) where
-      joinErrorMessages :: String -> String -> String
-      joinErrorMessages exp decl = intercalate "\n"
-        [ "Parsing input as an expression failed with \""  ++ exp  ++ "\""
-        , "Parsing input as an declaration failed with \"" ++ decl ++ "\""
+    HSE.ParseFailed _ declParseErr -> Left jointErrorMessage where
+      jointErrorMessage = join
+        [ "Parsing input as an expression failed with \"", expParseErr,  "\""
+        , "\n"
+        , "Parsing input as an declaration failed with \"", declParseErr, "\""
         ]
 

--- a/Plugin/Pl/Parser.hs
+++ b/Plugin/Pl/Parser.hs
@@ -2,6 +2,7 @@ module Plugin.Pl.Parser (parsePF) where
 
 import Plugin.Pl.Common
 
+import Data.List (intercalate)
 import qualified Language.Haskell.Exts as HSE
 
 todo :: (Functor e, Show (e ())) => e a -> r
@@ -93,6 +94,12 @@ parseMode =
 parsePF :: String -> Either String TopLevel
 parsePF inp = case HSE.parseExpWithMode parseMode inp of
   HSE.ParseOk e -> Right (TLE (hseToExpr e))
-  HSE.ParseFailed _ _ -> case HSE.parseDeclWithMode parseMode inp of
+  HSE.ParseFailed _ expParseErr -> case HSE.parseDeclWithMode parseMode inp of
     HSE.ParseOk d -> Right (TLD True (hseToDecl d))
-    HSE.ParseFailed _ err -> Left err
+    HSE.ParseFailed _ declParseErr -> Left (joinErrorMessages expParseErr declParseErr) where
+      joinErrorMessages :: String -> String -> String
+      joinErrorMessages exp decl = intercalate "\n"
+        [ "Parsing input as an expression failed with \""  ++ exp  ++ "\""
+        , "Parsing input as an declaration failed with \"" ++ decl ++ "\""
+        ]
+


### PR DESCRIPTION
Tiny PR - love this tool, have just been a little irked by this for a while so thought I'd throw this together. Hope you're accepting changes!

Currently `pointfree` tries to first parse the input as an expression, and should this fail, it tries to parse the input as a declaration, throwing away the error that caused failure the first time. As pointed out [here](https://github.com/bmillwood/pointfree/issues/28), this can make for some very confusing error messages. This tiny PR ensures both errors are printed in the case of failure, so the user knows what went wrong.

Minimal "failing" example without this edit is `pointfree "a . b ? c"`. 

Previously:
```
> pointfree "a . b ? c"
TemplateHaskell language extension is not enabled. Please add {-# LANGUAGE TemplateHaskell #-} pragma at the top of your module.
```

With change:
```
> pointfree "a . b ? c"
Parsing input as an expression failed with "Ambiguous infix expression"
Parsing input as an declaration failed with "TemplateHaskell language extension is not enabled. Please add {-# LANGUAGE TemplateHaskell #-} pragma at the top of your module."
```