### PR TITLE
Allow base-4.20 and QuickCheck-2.15

### DIFF
--- a/pointfree.cabal
+++ b/pointfree.cabal
@@ -29,7 +29,7 @@ Library
   Exposed-modules: Pointfree
   Default-language: Haskell2010
 
-  Build-depends: base >= 4.5 && < 4.20,
+  Build-depends: base >= 4.5 && < 4.21,
                  array >= 0.3 && < 0.6,
                  containers >= 0.4 && < 0.8,
                  haskell-src-exts >= 1.20 && < 1.24,
@@ -46,7 +46,7 @@ Executable pointfree
   Main-is:       Main.hs
   Default-language: Haskell2010
   GHC-options:   -W
-  Build-depends: base >= 4.5 && < 4.20,
+  Build-depends: base >= 4.5 && < 4.21,
                  array >= 0.3 && < 0.6,
                  containers >= 0.4 && < 0.8,
                  haskell-src-exts >= 1.20 && < 1.24,
@@ -70,12 +70,12 @@ Test-suite tests
                  Plugin.Pl.Transform
 
   Build-depends:
-    base >= 4.5 && < 4.20,
+    base >= 4.5 && < 4.21,
     array >= 0.3 && < 0.6,
     containers >= 0.4 && < 0.8,
     haskell-src-exts >= 1.20 && < 1.24,
     HUnit >= 1.6 && < 1.7,
-    QuickCheck >= 2.11 && < 2.15,
+    QuickCheck >= 2.11 && < 2.16,
     transformers < 0.7
 
   Default-language: Haskell2010


### PR DESCRIPTION
As a Hackage trustee I made a matching revision: https://hackage.haskell.org/package/pointfree-1.1.1.12/revisions/